### PR TITLE
Fix misleading Agent Auth Overview doc page

### DIFF
--- a/website/source/docs/agent/index.html.md
+++ b/website/source/docs/agent/index.html.md
@@ -43,7 +43,7 @@ These are the currently-available general configuration option:
 
 - `auto-auth` <tt>([auto-auth][autoauth]: \<optional\>)</tt> - Specifies the method and other options used for Auto-Auth functionality.
 
-- `caching` <tt>([caching][caching]: \<optional\>)</tt> - Specifies the listener address and other options used for Caching functionality. 
+- `cache` <tt>([cache][caching]: \<optional\>)</tt> - Specifies the listener address and other options used for Caching functionality. 
 
 - `pid_file` `(string: "")` - Path to the file in which the agent's Process ID
   (PID) should be stored
@@ -124,16 +124,16 @@ auto_auth {
 
 cache {
         use_auto_auth_token = true
+}
 
-        listener "unix" {
-                address = "/path/to/socket"
-                tls_disable = true
-        }
+listener "unix" {
+         address = "/path/to/socket"
+         tls_disable = true
+}
 
-        listener "tcp" {
-                address = "127.0.0.1:8100"
-                tls_disable = true
-        }
+listener "tcp" {
+         address = "127.0.0.1:8100"
+         tls_disable = true
 }
 ```
 


### PR DESCRIPTION
The example configuration in the Vault Agent Overview page is using wrong syntax
The configuration block is `cache` but doc is referencing it as `caching`